### PR TITLE
Add workflows to generate releases from tags and manually

### DIFF
--- a/.github/actions/ansible_release_log/action.yml
+++ b/.github/actions/ansible_release_log/action.yml
@@ -1,0 +1,56 @@
+---
+name: Ansible GitHub Release Logs
+author: Mark Chappell (tremble)
+branding:
+  icon: git-branch
+  color: gray-dark
+description: Generate Changelog entries for a GitHub release
+
+inputs:
+  release:
+    description: The release version to publish
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Prepare release environment
+      run: |
+        pip install rst-to-myst[sphinx]
+        pip install antsibull-changelog
+      shell: bash
+
+    - name: Checkout current ref
+      uses: actions/checkout@master
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Generate release log (RST)
+      run: |
+        antsibull-changelog generate -vvv --output changelog-release.rst --only-latest "${INPUT_RELEASE}"
+      shell: bash
+      env:
+        INPUT_RELEASE: ${{ inputs.release }}
+
+    - name: Upload RST release log
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog-rst
+        path: changelog-release.rst
+
+    - name: Convert release log (MD)
+      run: |
+        rst2myst convert changelog-release.rst
+        sed -i 's/^#/###/' changelog-release.md
+      shell: bash
+
+    - name: Upload MD release log
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog-md
+        path: changelog-release.md

--- a/.github/actions/ansible_release_tag/action.yml
+++ b/.github/actions/ansible_release_tag/action.yml
@@ -1,0 +1,40 @@
+---
+name: Ansible GitHub Release
+author: Mark Chappell (tremble)
+branding:
+  icon: git-branch
+  color: gray-dark
+description: Publish GitHub releases from an action
+
+inputs:
+  release:
+    description: The release version to publish
+    required: true
+
+  collection-name:
+    description: The name of the collection
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout current ref
+      uses: actions/checkout@master
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Download MD release log
+      uses: actions/download-artifact@v3
+      with:
+        name: changelog-md
+
+    - name: Create Release
+      run: |
+        ls
+        cat changelog-release.md
+        gh release create "${RELEASE}" --verify-tag  -t "${COLLECTION_NAME} ${RELEASE}" -F changelog-release.md
+      shell: bash
+      env:
+        COLLECTION_NAME: ${{ inputs.collection-name }}
+        RELEASE: ${{ inputs.release }}
+        GH_TOKEN: ${{ github.token }}

--- a/tools/files/tox-ansible.ini
+++ b/tools/files/tox-ansible.ini
@@ -8,6 +8,7 @@ skip =
     2.11
     2.12
     2.13
+    2.14
 
 [testenv:sanity-{py3.10,py3.11,py3.12}-devel]
 ignore_outcome = true

--- a/tools/tasks/render_workflow.yaml
+++ b/tools/tasks/render_workflow.yaml
@@ -27,3 +27,15 @@
   ansible.builtin.template:
     src: linters.yml.j2
     dest: '{{ collection_dir + "/.github/workflows/linters.yml" }}'
+
+- name: Set fact for collection name in dotted notation
+  ansible.builtin.set_fact:
+    collection_name: "{{ name | replace('/', '.') }}"
+
+- name: Copy the release workflow templates to the collection's gh workflow
+  ansible.builtin.template:
+    src: "{{ item + '.j2'}}" 
+    dest: '{{ collection_dir + "/.github/workflows/" + item }}'
+  loop:
+    - release-manual.yml
+    - release-tag.yml

--- a/tools/templates/release-manual.yml.j2
+++ b/tools/templates/release-manual.yml.j2
@@ -1,0 +1,39 @@
+---
+name: Generate GitHub Release (manual trigger)
+{% raw %}
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        required: true
+        description: Release to generate
+        type: string
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ inputs.release }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ inputs.release }}
+{%- endraw %}
+
+          collection-name: {{ collection_name }}

--- a/tools/templates/release-tag.yml.j2
+++ b/tools/templates/release-tag.yml.j2
@@ -1,0 +1,36 @@
+---
+name: Generate GitHub Release
+{% raw %}
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ github.ref_name }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ github.ref_name }}
+{%- endraw %}
+
+          collection-name: {{ collection_name }}

--- a/tools/vars/main.yaml
+++ b/tools/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-collection_path: /your/local/collection/path/
+collection_path: /home/gosriniv/github/collections/ansible_collections/
 collections:
   - amazon/aws
   - cloud/aws_ops

--- a/tools/vars/main.yaml
+++ b/tools/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-collection_path: /home/gosriniv/github/collections/ansible_collections/
+collection_path: /your/local/collection/path/
 collections:
   - amazon/aws
   - cloud/aws_ops


### PR DESCRIPTION
Refer: https://issues.redhat.com/browse/ACA-1642

This PR enables the configure_ci tool to scaffold the release-manual and release-tag GitHub workflows