### PR TITLE
Add new workflows to manages aws integration tests

### DIFF
--- a/.github/actions/ansible_read_targets/action.yml
+++ b/.github/actions/ansible_read_targets/action.yml
@@ -1,0 +1,45 @@
+name: Read ansible-test targets
+description: |
+  Read ansible-test targets for the job id. The action parses the output of
+  the ansible_test_splitter and retrieve the targets for the specific job.
+
+inputs:
+  job_id:
+    description: |
+      The job identifier (example: 'integration-amazon.aws-1')
+    required: true
+  all_targets:
+    description: |
+      The raw json data produces by the ansible_test_splitter action with
+      the list of targets.
+      (example: '{"integration-amazon.aws-1": "ec2_key", "integration-amazon.aws-2": "ec2_instance"}'
+    required: true
+outputs:
+  job_targets:
+    description: The corresponding targets to be executed by the job.
+    value: ${{ steps.parse-targets.outputs.job_targets }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse ansible_test_splitter result and retrieve job
+      id: parse-targets
+      uses: actions/github-script@v7
+      env:
+        TEST_TARGETS: '${{ inputs.all_targets }}'
+        JOB_ID: '${{ inputs.job_id }}'
+      with:
+        script: |
+          const TEST_TARGETS = process.env.TEST_TARGETS;
+          const JOB_ID = process.env.JOB_ID;
+
+          try {
+            const data = JSON.parse(TEST_TARGETS);
+            if (!(JOB_ID in data)){
+              core.setFailed(`Critical Error: The JSON data is missing the required key: '${JOB_ID}'`);
+            } else {
+              core.setOutput("job_targets", data[JOB_ID]);
+            }
+          } catch (error) {
+            core.setFailed(`Invalid JSON string: ${error.message}`);
+          }

--- a/.github/actions/ansible_read_targets/action.yml
+++ b/.github/actions/ansible_read_targets/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   all_targets:
     description: |
-      The raw json data produces by the ansible_test_splitter action with
+      The raw json data produced by the ansible_test_splitter action with
       the list of targets.
       (example: '{"integration-amazon.aws-1": "ec2_key", "integration-amazon.aws-2": "ec2_instance"}'
     required: true

--- a/.github/actions/ansible_test_splitter/action.yml
+++ b/.github/actions/ansible_test_splitter/action.yml
@@ -1,0 +1,86 @@
+name: Cloud integration test splitter
+description: Evaluate which targets need to be tested.
+
+inputs:
+  collections_to_test:
+    description: |
+      Path to the collections to test.
+      Provide as a comma-separated list of collection path and base ref to test against.
+      e.g: '~/runner/.ansible/collections/ansible_collections/amazon/aws,~/runner/.ansible/collections/ansible_collections/community/aws'
+    required: true
+  total_jobs:
+    description: The total number of jobs to share targets on
+    required: false
+    default: "3"
+  base_ref:
+    description: The git base branch to compare with.
+    required: true
+outputs:
+  jobs:
+    description: The list of jobs to be executed
+    value: ${{ steps.list-targets.outputs.jobs }}
+  targets:
+    description: The detailed targets for each job
+    value: ${{ steps.list-targets.outputs.targets }}
+
+runs:
+  using: composite
+  steps:
+    - name: setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Install python required libraries
+      run: pip install -U pyyaml
+      shell: bash
+
+    - name: Check if pull request contains label 'test-all-the-targets' to trigger all the targets
+      id: define-options
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let prNumber;
+
+          // Scenario 1: Direct Pull Request trigger
+          if (context.payload.pull_request) {
+            prNumber = context.payload.pull_request.number;
+            console.log(`Direct PR trigger. PR #${prNumber}`);
+          } 
+          // Scenario 2: Indirect Workflow Run trigger
+          else if (context.payload.workflow_run) {
+            // A workflow_run can be associated with multiple PRs; we take the first
+            prNumber = context.payload.workflow_run.pull_requests[0]?.number;
+            console.log(`Workflow Run trigger. Found associated PR #${prNumber}`);
+          }
+
+          if (!prNumber) {
+            core.setFailed("Could not find an associated Pull Request for this run.");
+            return;
+          }
+
+          // Fetch full PR details (this ensures we have the latest labels)
+          const { data: pullRequest } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          });
+
+          const labelNames = pullRequest.labels.map(l => l.name);
+          console.log(`Active Labels: ${labelNames.join(', ')}`);
+
+          let hasTestAllTheTargetsLabel = "false"
+          if (labelNames.includes('test-all-the-targets')) {
+            hasTestAllTheTargetsLabel = "true";
+          }
+          core.setOutput("test_all_the_targets", hasTestAllTheTargetsLabel);
+
+    - name: Run the test splitter
+      id: list-targets
+      run: python3 ${{ github.action_path }}/list_changed_targets.py
+      shell: bash
+      env:
+        SPLITTER_BASE_REF: '${{ inputs.base_ref }}'
+        SPLITTER_NUMBER_JOBS: '${{ inputs.total_jobs }}'
+        SPLITTER_COLLECTIONS_TO_TEST: '${{ inputs.collections_to_test }}'
+        SPLITTER_TEST_ALL_THE_TARGETS: '${{ steps.define-options.outputs.test_all_the_targets }}'

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -130,7 +130,7 @@ def build_import_tree(collection_path, collection_name, collections_names):
                     utils_import[utils].append(i)
                     if i not in visited:
                         utils_to_visit.append(i)
-        except:
+        except Exception:
             pass
     return modules_import, utils_import, inventories_import
 

--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+
+import ast
+import json
+from pathlib import PosixPath
+import subprocess
+import yaml
+import re
+from collections import defaultdict
+import os
+from typing import Optional
+
+
+def read_collection_name(path):
+    with (path / "galaxy.yml").open() as fd:
+        content = yaml.safe_load(fd)
+        return f'{content["namespace"]}.{content["name"]}'
+
+
+def list_pyimport(prefix, subdir, module_content):
+    root = ast.parse(module_content)
+    for node in ast.walk(root):
+        if isinstance(node, ast.Import):
+            yield node.names[0].name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module.split(".")
+            if node.level == 1:
+                current_prefix = f"{prefix}{subdir}."
+            elif node.level == 2:
+                current_prefix = f"{prefix}"
+            else:
+                current_prefix = ""
+            full_path = f"{current_prefix}{'.'.join(module)}"
+            yield full_path
+            # ensure we also catch any modules being imported using "from x.y import z"
+            for name in node.names:
+                yield f"{full_path}.{name.name}"
+
+
+def build_import_tree(collection_path, collection_name, collections_names):
+    """
+    This function will generate import dependencies for the modules and the module_utils.
+    Let say we have the following input:
+
+        modules: ec2_mod1
+            import a_py_mod
+            import ansible.basic
+        modules: ec2_mod2
+            import another_py_mod
+            import ansible_collections.amazon.aws.plugins.module_utils.core
+        modules: ec2_mod3
+            import ansible_collections.amazon.aws.plugins.module_utils.tagging
+            import ansible_collections.amazon.aws.plugins.module_utils.waiters
+
+        module_utils: waiters
+            import some_py_mod
+            import ansible_collections.amazon.aws.plugins.module_utils.core
+        module_utils: tagging
+            import some_py_tricky_mod
+            import ansible_collections.amazon.aws.plugins.module_utils.core
+        module_utils: core
+            import some_py_fancy_mod
+
+    This will generated the following dicts (list only import part of this collection):
+
+    modules_imports
+        {
+            "ec2_mod1": [],
+            "ec2_mod2": [
+                "ansible_collections.amazon.aws.plugins.module_utils.core",
+            ],
+            "ec2_instance_info": [
+                "ansible_collections.amazon.aws.plugins.module_utils.tagging",
+                "ansible_collections.amazon.aws.plugins.module_utils.waiters"
+            ],
+        }
+
+    utils_import
+        {
+            "ansible_collections.amazon.aws.plugins.module_utils.core": [
+                "ansible_collections.amazon.aws.plugins.module_utils.waiters"
+                "ansible_collections.amazon.aws.plugins.module_utils.tagging"
+            ]
+        }
+    """
+    modules_import = defaultdict(list)
+    prefix = f"ansible_collections.{collection_name}.plugins."
+    all_prefixes = [f"ansible_collections.{n}.plugins." for n in collections_names]
+    utils_to_visit = []
+    for mod in collection_path.glob("plugins/modules/*"):
+        for i in list_pyimport(prefix, "modules", mod.read_text()):
+            if (
+                any(i.startswith(p) for p in all_prefixes)
+                and i not in modules_import[mod.stem]
+            ):
+                modules_import[mod.stem].append(i)
+                if i not in utils_to_visit:
+                    utils_to_visit.append(i)
+
+    inventories_import = defaultdict(list)
+    prefix = f"ansible_collections.{collection_name}.plugins."
+    all_prefixes = [f"ansible_collections.{n}.plugins." for n in collections_names]
+    utils_to_visit = []
+    for mod in collection_path.glob("plugins/inventory/*"):
+        for i in list_pyimport(prefix, "inventory", mod.read_text()):
+            if (
+                any(i.startswith(p) for p in all_prefixes)
+                and i not in inventories_import[mod.stem]
+            ):
+                inventories_import[mod.stem].append(i)
+                if i not in utils_to_visit:
+                    utils_to_visit.append(i)
+
+    utils_import = defaultdict(list)
+    visited = []
+    while utils_to_visit:
+        utils = utils_to_visit.pop()
+        if utils in visited:
+            continue
+        visited.append(utils)
+        try:
+            utils_path = collection_path / PosixPath(
+                utils.replace(f"ansible_collections.{collection_name}.", "").replace(
+                    ".", "/"
+                )
+                + ".py"
+            )
+            for i in list_pyimport(prefix, "module_utils", utils_path.read_text()):
+                if i.startswith(prefix) and i not in utils_import[utils]:
+                    utils_import[utils].append(i)
+                    if i not in visited:
+                        utils_to_visit.append(i)
+        except:
+            pass
+    return modules_import, utils_import, inventories_import
+
+
+class WhatHaveChanged:
+    def __init__(self, path, branch):
+        assert isinstance(path, PosixPath)
+        self.collection_path = path
+        self.branch = branch
+        self.collection_name = lambda: read_collection_name(path)
+        self.files = None
+
+    def changed_files(self):
+        """List of changed files
+
+        Returns a list of pathlib.PosixPath
+        """
+        if self.files is None:
+            self.files = [
+                PosixPath(p)
+                for p in (
+                    subprocess.check_output(
+                        [
+                            "git",
+                            "diff",
+                            f"origin/{self.branch}",
+                            "--name-only",
+                        ],
+                        cwd=self.collection_path,
+                    )
+                    .decode()
+                    .split("\n")
+                )
+            ]
+        return self.files
+
+    def targets(self):
+        """List the test targets impacted by the change"""
+        for d in self.changed_files():
+            if str(d).startswith("tests/integration/targets/"):
+                # These are a special case, we only care that 'something' changed in that test
+                yield str(d).replace("tests/integration/targets/", "").split(
+                    "/", maxsplit=1
+                )[0]
+
+    def _path_matches(self, base_path):
+        # Simplest case, just a file name
+        for d in self.changed_files():
+            if str(d).startswith(base_path):
+                yield PosixPath(d)
+
+    def connection(self):
+        """List the connection plugins impacted by the change"""
+        yield from self._path_matches("plugins/connection/")
+
+    def inventory(self):
+        """List the inventory plugins impacted by the change"""
+        yield from self._path_matches("plugins/inventory/")
+
+    def lookup(self):
+        """List the lookup plugins impacted by the change"""
+        yield from self._path_matches("plugins/lookup/")
+
+    def modules(self):
+        """List the modules impacted by the change"""
+        yield from self._path_matches("plugins/modules/")
+
+    def _util_matches(self, base_path, import_path):
+        # We care about the file, but we also need to find what potential side effects would be for
+        # our change
+        base_path = PosixPath(base_path)
+        for d in self.changed_files():
+            try:
+                relative_path = d.relative_to(base_path)
+                parts = [*relative_path.parts[:-1]]
+                if d.stem != "__init__":
+                    parts.append(d.stem)
+                relative_module = ".".join(parts)
+                yield (
+                    PosixPath(d),
+                    f"ansible_collections.{self.collection_name()}.plugins.{import_path}.{relative_module}",
+                    relative_module,
+                )
+            except ValueError:
+                pass
+
+    def module_utils(self):
+        """List the Python modules impacted by the change"""
+        yield from self._util_matches("plugins/module_utils/", "module_utils")
+
+    def plugin_utils(self):
+        """List the Python modules impacted by the change"""
+        yield from self._util_matches("plugins/plugin_utils/", "plugin_utils")
+
+    def extensions_audit_event_query(self) -> bool:
+        """Return true when the extensions/audit/event_query.yml file has been updated"""
+        event_query_files = (
+            "extensions/audit/event_query.yml",
+            "extensions/audit/event_query.yaml",
+        )
+        return any([str(d) in event_query_files for d in self.changed_files()])
+
+
+class Target:
+    def __init__(self, path):
+        self.path = path
+        self.lines = [l.split("#")[0] for l in path.read_text().split("\n") if l]
+        self.name = path.parent.name
+        self.exec_time = None
+
+    def is_alias_of(self, name):
+        return name in self.lines or self.name == name
+
+    def is_unstable(self):
+        if "unstable" in self.lines:
+            return True
+        return False
+
+    def is_disabled(self):
+        if "disabled" in self.lines:
+            return True
+        return False
+
+    def is_slow(self):
+        # NOTE: Should be replaced by time=3000
+        if "slow" in self.lines or "# reason: slow" in self.lines:
+            return True
+        return False
+
+    def is_ignored(self):
+        """Show the target be ignored by default?"""
+        ignore = set(["unsupported", "disabled", "unstable", "hidden"])
+        return not ignore.isdisjoint(set(self.lines))
+
+    def execution_time(self):
+        if self.exec_time:
+            return self.exec_time
+
+        self.exec_time = 3000 if self.is_slow() else 180
+        for u in self.lines:
+            if m := re.match(r"^time=([0-9]+)s\S*$", u):
+                self.exec_time = int(m.group(1))
+            elif m := re.match(r"^time=([0-9]+)m\S*$", u):
+                self.exec_time = int(m.group(1)) * 60
+            elif m := re.match(r"^time=([0-9]+)\S*$", u):
+                self.exec_time = int(m.group(1))
+
+        return self.exec_time
+
+
+class Collection:
+    def __init__(self, path):
+        self.collection_path = path
+        self._my_test_plan = []
+        self.collection_name = lambda: read_collection_name(path)
+        self.modules_import = None
+        self.utils_import = None
+        self.inventories_import = None
+        self.test_groups = None
+
+    def _targets(self):
+        for a in self.collection_path.glob("tests/integration/targets/*/aliases"):
+            yield Target(a)
+
+    def _is_target_already_added(self, target_name):
+        """Return true if the target is already part of the test plan"""
+        for t in self._my_test_plan:
+            if t.is_alias_of(target_name):
+                return True
+        return False
+
+    def add_target_to_plan(self, target_name, is_direct=True):
+        if not self._is_target_already_added(target_name):
+            for t in self._targets():
+                if t.is_disabled():
+                    continue
+                # For indirect targets we want to skip "ignored" tests
+                if not is_direct and t.is_ignored():
+                    continue
+                if t.is_alias_of(target_name):
+                    self._my_test_plan.append(t)
+
+    def add_indirect_node_count_targets_to_plan(
+        self, alias_name="indirect_node_count", prefix_name="node_query_"
+    ):
+        for t in self._targets():
+            if self._is_target_already_added(t.name):
+                continue
+            if t.is_alias_of(alias_name) or t.name.startswith(prefix_name):
+                # add the target to the plan if either the name starts with 'node_query_' or
+                # the aliases file contains the line 'indirect_node_count'
+                self._my_test_plan.append(t)
+
+    def cover_all(self):
+        """Cover all the targets available."""
+        for t in self._targets():
+            self.add_target_to_plan(t.name, is_direct=False)
+
+    def cover_module_utils(self, pymod, collections_names):
+        """Track the targets to run follow up to a module_utils changed."""
+        if (
+            self.modules_import is None
+            or self.utils_import is None
+            or self.inventories_import is None
+        ):
+            (
+                self.modules_import,
+                self.utils_import,
+                self.inventories_import,
+            ) = build_import_tree(
+                self.collection_path, self.collection_name(), collections_names
+            )
+
+        u_candidates = [pymod]
+        for u in self.utils_import:
+            # add as candidates all module_utils which include this module_utils
+            if pymod in self.utils_import.get(u):
+                u_candidates.append(u)
+
+        for mod in self.modules_import:
+            intersect = [x for x in u_candidates if x in self.modules_import.get(mod)]
+            if intersect:
+                self.add_target_to_plan(mod, is_direct=False)
+
+        for inv in self.inventories_import:
+            intersect = [
+                x for x in u_candidates if x in self.inventories_import.get(inv)
+            ]
+            if intersect:
+                c.add_target_to_plan(f"inventory_{inv}")
+
+    def slow_targets_to_test(self):
+        return sorted(list(set([t.name for t in self._my_test_plan if t.is_slow()])))
+
+    def regular_targets_to_test(self):
+        return sorted(
+            list(set([t.name for t in self._my_test_plan if not t.is_slow()]))
+        )
+
+
+class ElGrandeSeparator:
+    def __init__(self, collections, total_jobs=13):
+        self.collections = collections
+        self.total_jobs = total_jobs  # aka slot
+        self.targets_per_slot = 10
+
+    def output(self, changes):
+        batches = []
+        for c in self.collections:
+            job_prefix = f"integration-{c.collection_name()}"
+            slots = [f"{job_prefix}-{i+1}" for i in range(self.total_jobs)]
+            for b in self.build_up_batches(slots, c):
+                batches.append(b)
+        result = self.build_result_struct(batches)
+        # add collection imports
+        result["imports"] = {}
+        for c in self.collections:
+            result["imports"][c.collection_name()] = {
+                "modules": c.modules_import,
+                "utils": c.utils_import,
+                "inventories": c.inventories_import,
+            }
+        result["what_have_changes"] = changes
+        github_output_file = os.environ.get("GITHUB_OUTPUT") or ""
+        if github_output_file:
+            with open(github_output_file, "a", encoding="utf-8") as file_write:
+                file_write.write(f"jobs={result['data']['jobs']}\n")
+                file_write.write(f"targets={json.dumps(result['data']['targets'])}\n")
+        print(f"[ANSIBLE_TEST_SPLITTER] =========  Output =========\n%s" % json.dumps(result, indent=2))
+
+    def build_up_batches(self, slots, c):
+        if c.test_groups is None:
+            sorted_targets = sorted(
+                c._my_test_plan, key=lambda x: x.execution_time(), reverse=True
+            )
+            c.test_groups = [{"total": 0, "targets": []} for _ in range(len(slots))]
+            c.test_groups = split_into_equally_sized_chunks(sorted_targets, len(slots))
+
+        for group in c.test_groups:
+            if group["targets"] == []:
+                continue
+            my_slot = slots.pop(0)
+            yield (my_slot, group["targets"])
+
+    def build_result_struct(self, batches):
+        result = {
+            "data": {
+                "jobs": [],
+                "targets": {},
+            }
+        }
+
+        for job, targets in batches:
+            result["data"]["jobs"].append(job)
+            result["data"]["targets"][job] = " ".join(targets)
+        return result
+
+
+def split_into_equally_sized_chunks(targets, nbchunks):
+    total_time = sum(x.execution_time() for x in targets)
+    time_per_chunk = int(total_time / nbchunks) + 1
+    chunks = [{"total": 0, "targets": []} for _ in range(nbchunks)]
+
+    def _findslot(t):
+        if t.execution_time() >= time_per_chunk:
+            # find first slot with total_time=0
+            for i, d in enumerate(chunks):
+                if d["total"] == 0:
+                    return i
+        else:
+            # find the appropriate slot
+            for i, d in enumerate(chunks):
+                if t.execution_time() + d["total"] <= time_per_chunk:
+                    return i
+        return 0
+
+    for t in targets:
+        at = _findslot(t)
+        chunks[at]["total"] += t.execution_time()
+        chunks[at]["targets"].append(t.name)
+    return chunks
+
+
+def read_value_from_env_variable(env_name: str, default_value: Optional[str] = None) -> str:
+    env_value = os.environ.get(env_name)
+    if not default_value and not env_value:
+        raise ValueError(f"Missing environment variable {env_name}")
+    return env_value or default_value
+
+
+def str_to_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif value.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise ValueError(f"Invalid boolean value: {value}")
+
+
+if __name__ == "__main__":
+
+    # Read parameters from environment variables
+    splitter_base_ref = read_value_from_env_variable("SPLITTER_BASE_REF")
+    print(f"[ANSIBLE_TEST_SPLITTER] Base ref => {splitter_base_ref}")
+    splitter_number_jobs = int(read_value_from_env_variable("SPLITTER_NUMBER_JOBS"))
+    print(f"[ANSIBLE_TEST_SPLITTER] Number Jobs => {splitter_number_jobs}")
+    splitter_collections_to_test = [PosixPath(c.strip()) for c in read_value_from_env_variable("SPLITTER_COLLECTIONS_TO_TEST").split(",") if c.strip()]
+    print(f"[ANSIBLE_TEST_SPLITTER] Collections to test => {splitter_collections_to_test}")
+    splitter_test_all_the_targets = str_to_bool(read_value_from_env_variable("SPLITTER_TEST_ALL_THE_TARGETS", False))
+    print(f"[ANSIBLE_TEST_SPLITTER] Test all the targets => {splitter_test_all_the_targets}")
+
+    collections = [Collection(i) for i in splitter_collections_to_test]
+    collections_names = [c.collection_name() for c in collections]
+
+    changes = {}
+    if splitter_test_all_the_targets:
+        for c in collections:
+            c.cover_all()
+    else:
+        for whc in [WhatHaveChanged(i, splitter_base_ref) for i in splitter_collections_to_test]:
+            changes[whc.collection_name()] = {
+                "modules": [],
+                "inventory": [],
+                "connection": [],
+                "module_utils": [],
+                "plugin_utils": [],
+                "lookup": [],
+                "targets": [],
+            }
+            for path in whc.modules():
+                changes[whc.collection_name()]["modules"].append(path.stem)
+                for c in collections:
+                    c.add_target_to_plan(path.stem)
+            for path in whc.inventory():
+                changes[whc.collection_name()]["inventory"].append(path.stem)
+                for c in collections:
+                    c.add_target_to_plan(f"inventory_{path.stem}")
+            for path in whc.connection():
+                changes[whc.collection_name()]["connection"].append(path.stem)
+                for c in collections:
+                    c.add_target_to_plan(f"connection_{path.stem}")
+            for path, pymod, stem in whc.module_utils():
+                changes[whc.collection_name()]["module_utils"].append(stem)
+                for c in collections:
+                    c.add_target_to_plan(f"module_utils_{stem.replace('.', '_')}")
+                    c.cover_module_utils(pymod, collections_names)
+            for path, pymodi, stem in whc.plugin_utils():
+                changes[whc.collection_name()]["plugin_utils"].append(stem)
+                for c in collections:
+                    c.add_target_to_plan(f"plugin_utils_{stem.replace('.', '_')}")
+                    c.cover_module_utils(pymodi, collections_names)
+            for path in whc.lookup():
+                changes[whc.collection_name()]["lookup"].append(path.stem)
+                for c in collections:
+                    c.add_target_to_plan(f"lookup_{path.stem}")
+            for t in whc.targets():
+                changes[whc.collection_name()]["targets"].append(t)
+                for c in collections:
+                    c.add_target_to_plan(t)
+            # indirect node count targets
+            if whc.extensions_audit_event_query():
+                for c in collections:
+                    c.add_indirect_node_count_targets_to_plan()
+
+    egs = ElGrandeSeparator(collections, splitter_number_jobs)
+    egs.output(changes)

--- a/.github/workflows/download-refs.yml
+++ b/.github/workflows/download-refs.yml
@@ -1,0 +1,60 @@
+name: Download PR refs artifacts
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the artifact to download.
+        type: string
+        default: 'base-ref'
+    outputs:
+      content:
+        description: The content of the reference file.
+        value: ${{ jobs.download.outputs.result }}
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.read-artifact.outputs.file_content }}
+    steps:
+      - name: Download Artifact
+        uses: actions/github-script@v7
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          WORKSPACE: ${{ github.workspace }}
+        with:
+          script: |
+            const { RUN_ID, ARTIFACT_NAME, WORKSPACE } = process.env;
+
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: Number(RUN_ID), // Convert string env to Number
+            });
+
+            const matchArtifact = artifacts.data.artifacts.find(
+              (artifact) => artifact.name === ARTIFACT_NAME
+            );
+
+            if (!matchArtifact) {
+              throw new Error(`Artifact not found: ${ARTIFACT_NAME}`);
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+
+            const fs = require('fs');
+            fs.writeFileSync(`${WORKSPACE}/ref.zip`, Buffer.from(download.data));
+
+      - name: Unzip downloaded artifact
+        id: read-artifact
+        run: |
+          unzip ref.zip -d .
+          # Read file and remove any trailing newlines
+          CONTENT=$(cat base-ref.txt | tr -d '\n')
+          echo "file_content=$CONTENT" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-job-status.yml
+++ b/.github/workflows/update-job-status.yml
@@ -1,0 +1,67 @@
+name: Update job status
+on:
+  workflow_call:
+    inputs:
+      job_name:
+        type: string
+        required: true
+        description: The name of the Job to update.
+      job_result:
+        description: The result of the job execution, if not provided the Job status should be set to 'pending'.
+        type: string
+        default: ''
+
+jobs:
+  commit-job-status:
+    name: Update Job status
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      job_name: '${{ inputs.job_name }}'
+      job_result: '${{ inputs.job_result }}'
+    steps:
+      - name: Commit workflow job status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const started = new Date(run.run_started_at);
+            const now = new Date();
+            const diff_seconds = Math.floor((now - started) / 1000);
+            const diff_minutes = Math.floor(diff_seconds / 60);
+            const remainder = diff_seconds % 60;
+            let conclusion = process.env.job_result;
+            let name = process.env.job_name;
+            const descriptions = {
+              'success': `Successful in ${diff_minutes}m ${remainder}s`,
+              'failure': 'Worfklow run failed, see logs for details',
+              'skipped': 'Integration tests skipped, no changed test targets identified',
+              'cancelled': 'Workflow run cancelled',
+              'error': 'Unexpected result, see logs for details',
+              'pending': 'This check has started...'
+            };
+            if (conclusion == '') {
+              status = 'pending';
+              conclusion = 'pending';
+            } else if (['success', 'skipped'].includes(conclusion)) {
+              status = 'success';
+            } else if (['cancelled', 'failure'].includes(conclusion)) {
+              status = 'failure';
+            } else {
+              conclusion = 'error';
+              status = 'failure';
+            };
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const target_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const args = {
+              owner: owner,
+              repo: repo,
+              sha: run.head_sha,
+              state: status,
+              target_url: run.html_url,
+              context: name,
+              description: descriptions[conclusion]
+            };
+            const result = await github.rest.repos.createCommitStatus(args);

--- a/.github/workflows/update-job-status.yml
+++ b/.github/workflows/update-job-status.yml
@@ -35,7 +35,7 @@ jobs:
             let name = process.env.job_name;
             const descriptions = {
               'success': `Successful in ${diff_minutes}m ${remainder}s`,
-              'failure': 'Worfklow run failed, see logs for details',
+              'failure': 'Workflow run failed, see logs for details',
               'skipped': 'Integration tests skipped, no changed test targets identified',
               'cancelled': 'Workflow run cancelled',
               'error': 'Unexpected result, see logs for details',

--- a/.github/workflows/upload-refs.yml
+++ b/.github/workflows/upload-refs.yml
@@ -1,0 +1,25 @@
+name: Upload PR refs artifacts
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the artifact to upload.
+        type: string
+        default: 'base-ref'
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Write PR base ref to file
+        run: |
+          mkdir -p ./pr
+          echo "${{ github.event.pull_request.base.ref }}" > ./pr/base-ref.txt
+
+      - name: Upload file as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ inputs.artifact_name }}"
+          path: ./pr/base-ref.txt
+          retention-days: 1


### PR DESCRIPTION
- `upload-refs`: A reusable workflow that captures and saves the PR reference into a GitHub artifact.
- `download-refs`: A reusable workflow designed to retrieve those stored PR references from artifacts for use in downstream jobs.
- `update-job-status`: A reusable workflow designed to update the status of a workflow triggered by a `workflow_run`
- `ansible_test_splitter`: The ansible test splitter github action
- `ansible_read_targets`: The github action used to read the targets to be executed for a specific job