### PR TITLE
Fix ansible-test-splitter to exclude hidden targets from test runs

### DIFF
--- a/.github/actions/ansible_test_splitter/list_changed_targets.py
+++ b/.github/actions/ansible_test_splitter/list_changed_targets.py
@@ -247,9 +247,9 @@ class Target:
         return False
 
     def is_disabled(self):
-        if "disabled" in self.lines:
-            return True
-        return False
+        """Check if target should never be run (disabled or hidden)"""
+        never_run = set(["disabled", "hidden"])
+        return not never_run.isdisjoint(set(self.lines))
 
     def is_slow(self):
         # NOTE: Should be replaced by time=3000
@@ -258,7 +258,7 @@ class Target:
         return False
 
     def is_ignored(self):
-        """Show the target be ignored by default?"""
+        """Check if target should be skipped when added indirectly"""
         ignore = set(["unsupported", "disabled", "unstable", "hidden"])
         return not ignore.isdisjoint(set(self.lines))
 


### PR DESCRIPTION
## Summary

Integration test targets marked as `hidden` (typically `setup_*` helper targets) were incorrectly included in test splits when they were modified directly. These targets should never be run as standalone tests, only pulled in as dependencies.

The issue was in the `Target.is_disabled()` method which only checked for the `disabled` marker. According to the [Ansible integration test aliases documentation](https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/integration-aliases.html), `hidden` targets should be treated the same as `disabled` - they should never be executed.

## Changes

- Updated `is_disabled()` to check for both `disabled` and `hidden` markers using the same set pattern as other marker checks
- Clarified `is_ignored()` docstring to indicate it's for indirect target filtering

This prevents `setup_*` targets from appearing in test job assignments even when they contain changes, resolving failures where these helper targets were run as standalone tests.

## Test Plan

- [ ] Manually verify with a collection that has modified `setup_*` targets that they no longer appear in test splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)