### PR TITLE
add precommit hooks to block ide and ai files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+.claude
 /tests/output/
 /tests/integration/integration_config.yml
 /tests/integration/inventory

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+-   id: block-ide-ai-files
+    name: block ai and ide files
+    description: ensure no .vscode or .claude files are staged.
+    entry: pre_commit_hooks/block-ide-files.sh
+    language: script
+    always_run: true
+    pass_filenames: true
+    stages: [pre-commit, pre-push, manual]
+    minimum_pre_commit_version: 3.2.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,6 @@
     description: ensure no .vscode or .claude files are staged.
     entry: pre_commit_hooks/block-ide-files.sh
     language: script
-    always_run: true
     pass_filenames: true
     stages: [pre-commit, pre-push, manual]
     minimum_pre_commit_version: 3.2.0

--- a/pre_commit_hooks/block-ide-files.sh
+++ b/pre_commit_hooks/block-ide-files.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Block commits containing .claude/ or .vscode/ files
+
+if git diff --cached --name-only | grep -qE "^\.claude/|^\.vscode/"; then
+    echo "=========================================="
+    echo "ERROR: Commit blocked!"
+    echo "=========================================="
+    echo ""
+    echo "The following IDE/config files are staged:"
+    git diff --cached --name-only | grep -E "^\.claude/|^\.vscode/"
+    echo ""
+    echo "Files from .claude/ and .vscode/ directories should not be committed."
+    echo "Please unstage these files before committing."
+    echo ""
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
A shared hook that will be used to block commit if any `.vscode/*` or `.claude/*` are staged