### PR TITLE
feat(ci): add security check action to block .claude/ and .vscode/ directories

### DIFF
--- a/.github/actions/security_check_directories/action.yml
+++ b/.github/actions/security_check_directories/action.yml
@@ -10,12 +10,11 @@ runs:
   steps:
     - name: Check for blocked directories in PR
       shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         echo "Checking for blocked directories in changed files..."
-
-        # Get the list of files changed in this PR
-        BASE_SHA="${{ github.event.pull_request.base.sha }}"
-        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
         if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
           echo "Not a pull request event, skipping check."

--- a/.github/actions/security_check_directories/action.yml
+++ b/.github/actions/security_check_directories/action.yml
@@ -23,7 +23,11 @@ runs:
         fi
 
         # Get changed files
-        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA" || true)
+        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA")
+        if [ $? -ne 0 ]; then
+          echo "::error::git diff failed unexpectedly."
+          exit 1
+        fi
 
         if [ -z "$CHANGED_FILES" ]; then
           echo "No changed files detected."
@@ -39,7 +43,8 @@ runs:
         FOUND_BLOCKED=""
 
         for pattern in $BLOCKED_PATTERNS; do
-          MATCHES=$(echo "$CHANGED_FILES" | grep "^${pattern}" || true)
+          # Match pattern at any depth (e.g., roles/myapp/.claude/ is also blocked)
+          MATCHES=$(echo "$CHANGED_FILES" | grep "${pattern}" || true)
           if [ -n "$MATCHES" ]; then
             FOUND_BLOCKED="${FOUND_BLOCKED}${MATCHES}"$'\n'
           fi

--- a/.github/actions/security_check_directories/action.yml
+++ b/.github/actions/security_check_directories/action.yml
@@ -1,0 +1,80 @@
+---
+name: Security Check - Block Unsafe Directories
+description: |
+  Blocks PRs that add files to .claude/ or .vscode/ directories.
+  These directories can contain configurations that execute code automatically,
+  posing a security risk to contributors.
+
+runs:
+  using: composite
+  steps:
+    - name: Check for blocked directories in PR
+      shell: bash
+      run: |
+        echo "Checking for blocked directories in changed files..."
+
+        # Get the list of files changed in this PR
+        BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+        if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+          echo "Not a pull request event, skipping check."
+          exit 0
+        fi
+
+        # Get changed files
+        CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE_SHA" "$HEAD_SHA" || true)
+
+        if [ -z "$CHANGED_FILES" ]; then
+          echo "No changed files detected."
+          exit 0
+        fi
+
+        echo "Changed files:"
+        echo "$CHANGED_FILES"
+        echo ""
+
+        # Check for blocked directories
+        BLOCKED_PATTERNS=".claude/ .vscode/"
+        FOUND_BLOCKED=""
+
+        for pattern in $BLOCKED_PATTERNS; do
+          MATCHES=$(echo "$CHANGED_FILES" | grep "^${pattern}" || true)
+          if [ -n "$MATCHES" ]; then
+            FOUND_BLOCKED="${FOUND_BLOCKED}${MATCHES}"$'\n'
+          fi
+        done
+
+        if [ -n "$FOUND_BLOCKED" ]; then
+          echo "::error::SECURITY VIOLATION: This PR contains files in blocked directories."
+          echo ""
+          echo "=========================================="
+          echo "BLOCKED FILES DETECTED"
+          echo "=========================================="
+          echo "$FOUND_BLOCKED"
+          echo ""
+          echo "=========================================="
+          echo "SECURITY RATIONALE"
+          echo "=========================================="
+          echo "The following directories are blocked from being added to this repository:"
+          echo ""
+          echo "  - .claude/  : Claude Code configuration files can contain hooks and commands"
+          echo "                that execute automatically when contributors use Claude Code."
+          echo "                Malicious configurations could run arbitrary code on developer"
+          echo "                machines without their knowledge."
+          echo ""
+          echo "  - .vscode/  : VS Code configuration files can contain tasks, launch configs,"
+          echo "                and extension settings that execute automatically. These could"
+          echo "                be exploited to run malicious code when opening the project."
+          echo ""
+          echo "This is a defense-in-depth measure. Even if local pre-commit hooks are"
+          echo "bypassed (using --no-verify), this CI check ensures these directories"
+          echo "cannot be merged into the repository."
+          echo ""
+          echo "If you believe this is a false positive, please contact the maintainers."
+          echo "=========================================="
+          exit 1
+        fi
+
+        echo "No blocked directories found in changed files."
+        echo "Security check passed."


### PR DESCRIPTION
## Summary
- Add composite action `security_check_directories` that blocks PRs containing files under `.claude/` or `.vscode/` directories
- These directories can contain configurations that execute code automatically, posing a security risk to contributors
- Provides defense in depth - even if local pre-commit hooks are bypassed with `--no-verify`, this CI check prevents merging

## Test plan
- [ ] Create a test branch with a file at `.claude/test.json`
- [ ] Open a PR and verify the action fails with appropriate error message
- [ ] Verify PR cannot be merged due to failing check

Ref: ACA-6411

🤖 Generated with [Claude Code](https://claude.com/claude-code)