### PR TITLE
CICD Change Detection

### DIFF
--- a/.github/actions/cicd_change_detector/README.md
+++ b/.github/actions/cicd_change_detector/README.md
@@ -25,11 +25,14 @@ jobs:
 
 > **Note:** The example above uses `@main`. For stricter supply-chain security, pin to a commit SHA (e.g., `@a1b2c3d`).
 
+> **Note:** Ensure the workflow has `pull-requests: write` permission. In repositories with restricted `GITHUB_TOKEN` permissions, you may need to explicitly grant this in Settings → Actions → General → Workflow permissions.
+
 ## Inputs
 
 | Name | Required | Description |
 |------|----------|-------------|
 | `github-token` | Yes | GitHub token with `pull-requests: write` permission |
+| `label-name` | No | Optional label to add when CI/CD files are detected |
 
 ## Behavior
 
@@ -37,3 +40,16 @@ When CI/CD files are detected in a PR, the action:
 
 1. Adds a `ci-cd-change` label to the PR (creates the label in the repo if it doesn't exist)
 2. Posts a one-time security review checklist comment (skips if already posted)
+
+ ## Detected Files and Patterns
+
+  The following files and directories are flagged as CI/CD configuration:
+
+  | Pattern | Description |
+  |---------|-------------|
+  | `.github/workflows/*.yml` / `.yaml` | GitHub Actions workflow definitions |
+  | `.github/actions/**` | GitHub composite and custom actions |
+  | `Makefile` / `makefile` / `GNUmakefile` | Build automation |
+  | `tox.ini` | Python test automation |
+  | `noxfile.py` | Python test automation |
+  | `.zuul.yaml` / `.zuul.d/**` | Zuul CI configuration |

--- a/.github/actions/cicd_change_detector/README.md
+++ b/.github/actions/cicd_change_detector/README.md
@@ -1,0 +1,39 @@
+# CI/CD Change Detector
+
+Detects when a PR modifies CI/CD configuration files and flags them for enhanced security review by adding a `ci-cd-change` label and posting a review checklist comment.
+
+## Usage
+
+```yaml
+name: CI/CD Change Detection
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cicd-change-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect CI/CD changes
+        uses: ansible/cloud-content-ci-automation/.github/actions/cicd_change_detector@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+> **Note:** The example above uses `@main`. For stricter supply-chain security, pin to a commit SHA (e.g., `@a1b2c3d`).
+
+## Inputs
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `github-token` | Yes | GitHub token with `pull-requests: write` permission |
+
+## Behavior
+
+When CI/CD files are detected in a PR, the action:
+
+1. Adds a `ci-cd-change` label to the PR (creates the label in the repo if it doesn't exist)
+2. Posts a one-time security review checklist comment (skips if already posted)

--- a/.github/actions/cicd_change_detector/action.yml
+++ b/.github/actions/cicd_change_detector/action.yml
@@ -12,7 +12,7 @@ inputs:
       Typically secrets.GITHUB_TOKEN.
     required: true
   label-name:
-    description: 'Label to add when CI/CD files are Detected'
+    description: 'Label to add when CI/CD files are detected'
     required: false
     default: 'ci-cd-change'
 

--- a/.github/actions/cicd_change_detector/action.yml
+++ b/.github/actions/cicd_change_detector/action.yml
@@ -1,0 +1,144 @@
+---
+name: CI/CD Change Detector
+description: |
+  Detects when a PR modifies CI/CD configuration files and flags them
+  for enhanced security review by adding a label and posting a review
+  checklist comment.
+
+inputs:
+  github-token:
+    description: >
+      GitHub token with permissions to add labels and post comments.
+      Typically secrets.GITHUB_TOKEN.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Detect CI/CD changes and apply label and checklist
+      id: detect
+      uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
+          if (!prNumber) {
+            core.info('Not a pull_request event or PR number not found. Skipping.');
+            return;
+          }
+
+          const files = await github.paginate(
+            github.rest.pulls.listFiles,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            }
+          );
+
+          const isCiCdFile = (filename) => {
+            if (filename.startsWith('.github/workflows/') &&
+                (filename.endsWith('.yml') || filename.endsWith('.yaml'))) {
+              return true;
+            }
+            if (filename.startsWith('.github/actions/')) return true;
+            if (filename === 'Makefile') return true;
+            if (filename === 'tox.ini') return true;
+            if (filename === 'noxfile.py') return true;
+            if (filename === '.zuul.yaml') return true;
+            if (filename.startsWith('.zuul.d/')) return true;
+            return false;
+          };
+
+          const ciCdFiles = files
+            .map(f => f.filename)
+            .filter(isCiCdFile);
+
+          if (ciCdFiles.length === 0) {
+            core.info('No CI/CD configuration files changed.');
+            return;
+          }
+
+          core.info(`CI/CD files changed: ${ciCdFiles.join(', ')}`);
+
+          const labelName = 'ci-cd-change';
+          try {
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [labelName],
+            });
+            core.info(`Label '${labelName}' added to PR #${prNumber}.`);
+          } catch (error) {
+            if (error.status === 404) {
+              core.info(`Label '${labelName}' not found in repo. Creating it.`);
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: 'e11d48',
+                description: 'PR modifies CI/CD configuration files',
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [labelName],
+              });
+              core.info(`Label '${labelName}' created and added to PR #${prNumber}.`);
+            } else {
+              throw error;
+            }
+          }
+
+          const marker = '<!-- cicd-change-detector-checklist -->';
+          const comments = await github.paginate(
+            github.rest.issues.listComments,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            }
+          );
+
+          const existingComment = comments.find(c => c.body && c.body.includes(marker));
+          if (existingComment) {
+            core.info('Checklist comment already exists. Skipping.');
+            return;
+          }
+
+          const fileList = ciCdFiles.map(f => `- \`${f}\``).join('\n');
+          const body = [
+            marker,
+            '## :shield: CI/CD Configuration Change Detected',
+            '',
+            'This PR modifies CI/CD configuration files that may have elevated privileges.',
+            'Please ensure the following security review checklist is completed before merging.',
+            '',
+            '### Changed CI/CD files',
+            fileList,
+            '',
+            '### Security Review Checklist',
+            '',
+            '- [ ] **Secrets handling**: No secrets, tokens, or credentials are hardcoded or logged',
+            '- [ ] **Permission scope**: Workflow permissions follow least privilege (`permissions:` block is present and scoped)',
+            '- [ ] **Third-party actions**: New or updated actions are pinned to a full commit SHA, not a mutable tag',
+            '- [ ] **Script injection**: `run:` steps do not use unsanitized `${{ }}` expressions that could enable injection',
+            '- [ ] **Artifact safety**: Uploaded/downloaded artifacts do not contain sensitive data',
+            '- [ ] **Environment protection**: Production environments have required reviewers configured',
+            '- [ ] **Test coverage**: Changes to test config (tox.ini, noxfile.py) do not reduce coverage or skip critical tests',
+            '- [ ] **Reviewer approval**: A second reviewer with CI/CD expertise has reviewed these changes',
+          ].join('\n');
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            body: body,
+          });
+          core.info('Security review checklist comment posted.');

--- a/.github/actions/cicd_change_detector/action.yml
+++ b/.github/actions/cicd_change_detector/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Detect CI/CD changes and apply label and checklist
       id: detect
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       with:
@@ -74,7 +74,7 @@ runs:
             });
             core.info(`Label '${labelName}' added to PR #${prNumber}.`);
           } catch (error) {
-            if (error.status === 404) {
+            if (error.status === 422 || error.status === 404) {
               core.info(`Label '${labelName}' not found in repo. Creating it.`);
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,

--- a/.github/actions/cicd_change_detector/action.yml
+++ b/.github/actions/cicd_change_detector/action.yml
@@ -11,6 +11,18 @@ inputs:
       GitHub token with permissions to add labels and post comments.
       Typically secrets.GITHUB_TOKEN.
     required: true
+  label-name:
+    description: 'Label to add when CI/CD files are Detected'
+    required: false
+    default: 'ci-cd-change'
+
+outputs:
+  ci-cd-files-changed:
+    description: "true if CI/CD files were detected, false otherwise"
+    value: ${{ steps.detect.outputs.changed }}
+  changed-file-count:
+    description: "Number of CI/CD files changed"
+    value: ${{ steps.detect.outputs.count }}
 
 runs:
   using: composite
@@ -20,11 +32,14 @@ runs:
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        LABEL_NAME: ${{ inputs.label-name }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           const prNumber = parseInt(process.env.PR_NUMBER, 10);
-          if (!prNumber) {
+          core.setOutput('changed', 'false');
+          core.setOutput('count', '0');
+          if (!prNumber || isNaN(prNumber)) {
             core.info('Not a pull_request event or PR number not found. Skipping.');
             return;
           }
@@ -45,7 +60,7 @@ runs:
               return true;
             }
             if (filename.startsWith('.github/actions/')) return true;
-            if (filename === 'Makefile') return true;
+            if (filename.match(/^(Makefile|makefile|GNUmakefile)$/)) return true;
             if (filename === 'tox.ini') return true;
             if (filename === 'noxfile.py') return true;
             if (filename === '.zuul.yaml') return true;
@@ -59,12 +74,16 @@ runs:
 
           if (ciCdFiles.length === 0) {
             core.info('No CI/CD configuration files changed.');
+            core.setOutput('changed', 'false');
+            core.setOutput('count', '0');
             return;
           }
+          core.setOutput('changed', 'true');
+          core.setOutput('count', ciCdFiles.length.toString());
 
           core.info(`CI/CD files changed: ${ciCdFiles.join(', ')}`);
 
-          const labelName = 'ci-cd-change';
+          const labelName = process.env.LABEL_NAME;
           try {
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -91,6 +110,7 @@ runs:
               });
               core.info(`Label '${labelName}' created and added to PR #${prNumber}.`);
             } else {
+              core.setFailed(`Failed to add label: ${error.message}`);
               throw error;
             }
           }
@@ -121,6 +141,8 @@ runs:
             'Please ensure the following security review checklist is completed before merging.',
             '',
             '### Changed CI/CD files',
+            `**${ciCdFiles.length} files require security review:**`,
+            '',
             fileList,
             '',
             '### Security Review Checklist',

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ A repository of tools that can be used to automate CI configurations/functionali
 ## Tools
 
 - **[tools/github-to-jira-utility/](tools/github-to-jira-utility/)** — Syncs GitHub issues (with the `jira` label) to ACA Jira issues (e.g. via Lambda). See that folder's README for setup and usage.
+
+## Actions
+
+- **[.github/actions/security_check_directories/](.github/actions/security_check_directories/)** — Blocks PRs that add files to `.claude/` or `.vscode/` directories.
+- **[.github/actions/cicd_change_detector/](.github/actions/cicd_change_detector/)** — Flags PRs that modify CI/CD configuration files with a label and security review checklist.


### PR DESCRIPTION
Added a change detection workflow for CICD files that can be called by other repositories and relevant documentation, following the established pattern of this repository.

Addresses https://redhat.atlassian.net/browse/ACA-6410

Assisted-by: Claude Opus 4.6